### PR TITLE
feat: add deterministic pk option for SA creation

### DIFF
--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -66,6 +66,7 @@ const Index = () => {
 
   const [accountId, setAccountId] = useState<string | null>();
   const [accountObject, setAccountObject] = useState<string | null>();
+  const [counter, setCounter] = useState<number>(0);
 
   const client = new KeyringSnapRpcClient(snapId, window.ethereum);
   const abiCoder = new ethers.AbiCoder();
@@ -82,6 +83,12 @@ const Index = () => {
       }
       const accounts = await client.listAccounts();
       console.log(`accounts loaded!`, accounts)
+
+      const saltIndexCount = accounts.filter(
+        (account) => account.options?.saltIndex,
+      ).length;
+      setCounter(saltIndexCount);
+
       // listRequests
       setSnapState({
         ...state,
@@ -107,6 +114,15 @@ const Index = () => {
       privateKey: privateKey as string,
       salt: salt as string,
     });
+    await syncAccounts();
+    return newAccount;
+  };
+
+  const createAccountDeterministic = async () => {
+    const newAccount = await client.createAccount({
+      saltIndex: counter.toString(),
+    });
+    setCounter(counter + 1);
     await syncAccounts();
     return newAccount;
   };
@@ -413,6 +429,25 @@ const Index = () => {
       ],
       action: {
         callback: async () => await createAccount(),
+        label: 'Create Account',
+      },
+      successMessage: 'Smart Contract Account Created',
+    },
+    {
+      name: 'Create account (Deterministic)',
+      description:
+        'Create a 4337 account using a deterministic key generated through the snap',
+      inputs: [
+        {
+          id: 'create-account-deterministic',
+          title: 'Counter',
+          value: counter.toString(),
+          type: InputType.TextField,
+          onChange: () => {},
+        },
+      ],
+      action: {
+        callback: async () => await createAccountDeterministic(),
         label: 'Create Account',
       },
       successMessage: 'Smart Contract Account Created',

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bobanetwork/snap-account-abstraction-keyring",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "An account abstraction keyring snap that integrates with MetaMask accounts on Boba Network",
   "keywords": [
     "metamask",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/bobanetwork/snap-account-abstraction-keyring.git"
   },
   "source": {
-    "shasum": "VwrhJjmmMzoiIDC5IKuuFWfuLF2XELEFPak1RQhwlUM=",
+    "shasum": "FmxpL3AcCA6vgh5mxXt822k8JP6jRKgRnFbpgxuj1BU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -32,6 +32,7 @@
     "snap_notify": {},
     "snap_manageAccounts": {},
     "snap_manageState": {},
+    "snap_getEntropy": {},
     "endowment:ethereum-provider": {},
     "endowment:network-access": {}
   },

--- a/packages/snap/src/keyring.ts
+++ b/packages/snap/src/keyring.ts
@@ -222,10 +222,8 @@ export class AccountAbstractionKeyring implements Keyring {
   async createAccount(
     options: Record<string, Json> = {},
   ): Promise<KeyringAccount> {
-    if (!options.privateKey) {
-      if (!options.saltIndex) {
-        throwError(`[Snap] Private Key or Salt Index is required`);
-      }
+    if (!options.privateKey && !options.saltIndex) {
+      throwError(`[Snap] Private Key or Salt Index is required`);
     }
 
     const privateKeyGen =

--- a/packages/snap/src/utils/util.ts
+++ b/packages/snap/src/utils/util.ts
@@ -1,4 +1,5 @@
 import type { JsonTx } from '@ethereumjs/tx';
+import { stripHexPrefix } from '@ethereumjs/util';
 import type { Json } from '@metamask/utils';
 import { hexlify } from 'ethers';
 
@@ -95,3 +96,19 @@ export function runSensitive<Type>(
     throw new Error(message ?? 'An unexpected error occurred');
   }
 }
+
+export const getSignerPrivateKey = async (index: number) => {
+  try {
+    return stripHexPrefix(
+      await snap.request({
+        method: 'snap_getEntropy',
+        params: {
+          version: 1,
+          salt: `signer_${index}`,
+        },
+      }),
+    );
+  } catch (e) {
+    throw new Error(`Failed to get signer private key for index ${index}`);
+  }
+};


### PR DESCRIPTION
## Overview
Adds a second "Smart Account" creation option where user's use a snap generated deterministic PK for their SA signer.

## Changes
- Added option for account creation without supplying PK (or any inputs)
- auto update counter based on known accounts, Deterministic SA generation is index based like metamask
- removed collision check to allow re-adding already deployed SAs

## Screenshots
(Counter is not an input here)


<img width="1405" alt="Screenshot 2024-06-12 at 6 05 55 PM" src="https://github.com/bobanetwork/snap-account-abstraction-keyring/assets/26090752/5a6f2006-d391-451b-84ce-e5f5dffb2415">