### PR TITLE
remove any origin usage on snap

### DIFF
--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -36,10 +36,6 @@ async function getKeyring(): Promise<AccountAbstractionKeyring> {
  * @returns True if the caller is allowed to call the method, false otherwise.
  */
 function hasPermission(origin: string, method: string): boolean {
-  // Note: Allow origin to be any for hackathon usage
-  if (method === InternalMethod.SendUserOpBoba) {
-    return true;
-  }
   return originPermissions.get(origin)?.includes(method) ?? false;
 }
 


### PR DESCRIPTION
## Overview
Remove support for any origin on the hc-snap. (This was added for hackathon usage)